### PR TITLE
Added SeriesSort tag

### DIFF
--- a/drafts/v2.1/ComicInfo.xsd
+++ b/drafts/v2.1/ComicInfo.xsd
@@ -5,6 +5,7 @@
         <xs:sequence>
             <xs:element minOccurs="0" maxOccurs="1" default="" name="Title" type="xs:string" />
             <xs:element minOccurs="0" maxOccurs="1" default="" name="Series" type="xs:string" />
+            <xs:element minOccurs="0" maxOccurs="1" default="" name="SeriesSort" type="xs:string" />
             <xs:element minOccurs="0" maxOccurs="1" default="" name="Number" type="xs:string" />
             <xs:element minOccurs="0" maxOccurs="1" default="-1" name="Count" type="xs:int" />
             <xs:element minOccurs="0" maxOccurs="1" default="-1" name="Volume" type="xs:int" />


### PR DESCRIPTION
Implements support for #4 by adding a new tag, SeriesSort, which allows users to specify sort order for series with ComicInfo.