### PR TITLE
chore: fix typo in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/report_feature.yml
+++ b/.github/ISSUE_TEMPLATE/report_feature.yml
@@ -8,7 +8,7 @@ body:
   - type: textarea
     id: from
     attributes:
-      label: Where does this comes from?
+      label: Where does this come from?
       description: Has this been discussed somewhere?
       placeholder: |
         Example:


### PR DESCRIPTION
I was wondering why all the issues started with "where does this comes from" so I decided to check the issue template and noticed that it was a typo there. Figured I would submit a pull request fixing it.